### PR TITLE
fix: pass source metadata to generateMap in vite plugin

### DIFF
--- a/src/vite.ts
+++ b/src/vite.ts
@@ -34,7 +34,7 @@ export async function comptime(opts?: ComptimeVitePluginOpts): Promise<Plugin> {
 				s.overwrite(r.start, r.end, r.replacement);
 			}
 
-			return { code: s.toString(), map: s.generateMap() };
+			return { code: s.toString(), map: s.generateMap({ source: id, includeContent: true }) };
 		},
 		async handleHotUpdate({ modules, file }) {
 			if (!filter(file)) return;

--- a/tests/comptime.test.ts
+++ b/tests/comptime.test.ts
@@ -4,6 +4,8 @@ import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { comptimeCompiler } from "../src/api.ts";
 import { formatPath } from "../src/resolve.ts";
+import { getComptimeReplacements } from "../src/comptime.ts";
+import MagicString from "magic-string";
 
 const randId = () => Math.random().toString(36).substring(2, 15);
 
@@ -810,5 +812,39 @@ describe("comptime", () => {
 		`;
 		const result = await getCompiled("foo.ts");
 		expect(result).toEqual(expected);
+	});
+
+	it("should generate sourcemaps with valid sources", async () => {
+		await file(
+			"foo.ts",
+			`
+			import { sum } from "./bar.ts" with { type: "comptime" };
+			console.log(sum(1, 2));
+		`,
+		);
+		await file(
+			"bar.ts",
+			`
+			export function sum(a: number, b: number) { return a + b; }
+		`,
+		);
+
+		const tsconfigPath = join(temp, "tsconfig.json");
+		const replacements = await getComptimeReplacements({ tsconfigPath });
+
+		for (const [id, repls] of Object.entries(replacements)) {
+			if (!repls.length) continue;
+
+			const mod = await readFile(id, "utf-8");
+			const s = new MagicString(mod);
+			for (const r of repls) {
+				s.overwrite(r.start, r.end, r.replacement);
+			}
+
+			const map = s.generateMap({ source: id, includeContent: true });
+			expect(map.sources).not.toContain("..");
+			expect(map.sources).not.toContain("");
+			expect(map.sources[0]).toEqual(id);
+		}
 	});
 });


### PR DESCRIPTION
Thanks for making such a great library! I love comptime. :-) 

I am using this in a monorepo. The package I'm building uses the vite plugin for a tsdown build. That build is in-turn consumed by downstream bundlers (e.g. turbopack in Next.js 16) and they choke on sourcemaps produced by the vite plugin because generateMap() is called without options, resulting in sources: [".."] instead of real file paths. Turbopack tries to resolve these and fails with "Is a directory".

This passes `source: id` and `includeContent: true` to generateMap() so the sourcemap contains the actual file path and original source content.